### PR TITLE
Añadir `relative` al contenedor de la imagen de vista previa

### DIFF
--- a/src/app/create/page.tsx
+++ b/src/app/create/page.tsx
@@ -489,7 +489,7 @@ export default function CreateListingPage() {
           <div className="rounded-2xl border border-white/10 bg-obsidian-900/60 p-6">
             <h3 className="text-base font-semibold text-white">Live preview</h3>
             <div className="mt-4 overflow-hidden rounded-2xl border border-white/10 bg-obsidian-950/70">
-              <div className="aspect-square overflow-hidden border-b border-white/10 bg-obsidian-900/80">
+              <div className="relative aspect-square overflow-hidden border-b border-white/10 bg-obsidian-900/80">
                 {previewImage ? (
                   <Image
                     src={previewImage}


### PR DESCRIPTION
### Motivación
- Evitar que la imagen con `fill` de `next/image` desborde el marco cuadrado y asegurar que se posicione relativo al contenedor.
- Permitir que la utilidad `aspect-square` actúe como el marco visual para la imagen.
- Garantizar que la clase `object-cover` recorte la imagen dentro del cuadrado en lugar de estirarla.

### Descripción
- Se añadió la clase `relative` al `div` que envuelve la imagen de la vista previa en `src/app/create/page.tsx` (el contenedor con `aspect-square`).
- No se hicieron cambios adicionales en la lógica ni en los textos de la vista previa.

### Testing
- Se ejecutó `npm run dev` y el servidor de desarrollo de Next.js arrancó correctamente. 
- Se intentó capturar una pantalla con Playwright navegando a `http://localhost:3000/create`, pero Chromium falló en este entorno y la captura no se pudo completar. 
- No se ejecutaron otras suites de tests automatizados sobre el cambio.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696516db6dd483329edf7fab6244d009)