### PR TITLE
Use VPS-backed registry APIs

### DIFF
--- a/src/app/create/page.tsx
+++ b/src/app/create/page.tsx
@@ -208,7 +208,7 @@ export default function CreateListingPage() {
     reader.readAsDataURL(file);
   };
 
-  const handlePublish = () => {
+  const handlePublish = async () => {
     if (!canPublish) {
       return;
     }
@@ -232,8 +232,12 @@ export default function CreateListingPage() {
         terms?.kind === "token" ? terms.sellAtoms.toString() : verification?.amountAtoms,
       verification: verification?.status ?? "unknown"
     };
-    addListing(listing);
-    router.push(`/?highlight=${listing.id}`);
+    try {
+      await addListing(listing);
+      router.push(`/?highlight=${listing.id}`);
+    } catch (err) {
+      alert("Error al publicar en el servidor global.");
+    }
   };
 
   return (

--- a/src/components/MarketplaceClient.tsx
+++ b/src/components/MarketplaceClient.tsx
@@ -41,7 +41,9 @@ export function MarketplaceClient({ listings }: MarketplaceClientProps) {
   }, [initialCollection]);
 
   useEffect(() => {
-    setRegistryListings(loadRegistry());
+    loadRegistry().then((data) => {
+      setRegistryListings(data);
+    });
   }, []);
 
   const initialTabRef = useRef(true);


### PR DESCRIPTION
### Motivation

- Move registry persistence from local `localStorage` to a centralized VPS API so listings are shared globally.
- Ensure UI components wait for network responses before rendering or navigating to avoid race conditions.
- Keep deletion logic as a backend responsibility because the API does not yet expose `DELETE` semantics.

### Description

- Replace `src/lib/registry.ts` with async network-backed functions: `loadRegistry()` and `addListing()` that use `fetch` to `http://72.62.161.240:3001/listings`, and make `isRegistryPersistent()` return `true` while removing localStorage/cache logic.
- Update `src/components/MarketplaceClient.tsx` to load listings asynchronously by calling `loadRegistry().then(...)` inside the `useEffect` that populates `registryListings`.
- Modify `src/app/create/page.tsx` to make `handlePublish` `async`, `await addListing(listing)`, and wrap the call in `try/catch` to alert on publish failures and block navigation until the server confirms the save.
- Leave `removeListing` as a placeholder that logs a warning and returns an empty array until backend delete support is implemented.

### Testing

- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6966592765708332ab9255f73a4212bc)