### PR TITLE
Normalize registry data and load item details from VPS

### DIFF
--- a/src/app/item/[id]/page.tsx
+++ b/src/app/item/[id]/page.tsx
@@ -1,33 +1,36 @@
-import { notFound } from "next/navigation";
-import listings from "@/data/listings.json";
-import { ListingCard } from "@/components/ListingCard";
-import type { Listing } from "@/lib/types";
+"use client";
+
+import { useEffect, useState } from "react";
+import { loadRegistry, type RegistryListing } from "@/lib/registry";
+import { ListingDetails } from "@/components/ListingDetails";
 
 interface ItemPageProps {
   params: { id: string };
 }
 
 export default function ItemPage({ params }: ItemPageProps) {
-  const typedListings = listings as Listing[];
-  const listing = typedListings.find((item) => item.id === params.id);
+  const [listing, setListing] = useState<RegistryListing | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    loadRegistry().then((listings) => {
+      const found = listings.find((l) => l.id === params.id);
+      setListing(found || null);
+      setLoading(false);
+    });
+  }, [params.id]);
+
+  if (loading) {
+    return <div className="p-8 text-center">Cargando templo...</div>;
+  }
 
   if (!listing) {
-    notFound();
+    return <div className="p-8 text-center">Listado no encontrado.</div>;
   }
 
   return (
-    <div className="space-y-10">
-      <section className="rounded-3xl border border-white/10 bg-obsidian-900/70 px-6 py-10">
-        <p className="text-xs uppercase tracking-[0.4em] text-white/50">Detalle</p>
-        <h1 className="mt-4 text-3xl font-semibold text-white md:text-4xl">
-          {listing.name}
-        </h1>
-        <p className="mt-3 max-w-2xl text-sm text-white/70">{listing.description}</p>
-      </section>
-
-      <div className="max-w-md">
-        <ListingCard listing={listing} />
-      </div>
+    <div className="container py-8">
+      <ListingDetails listing={listing} />
     </div>
   );
 }

--- a/src/components/ListingDetails.tsx
+++ b/src/components/ListingDetails.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import Image from "next/image";
+import type { RegistryListing } from "@/lib/registry";
+
+interface ListingDetailsProps {
+  listing: RegistryListing;
+}
+
+export function ListingDetails({ listing }: ListingDetailsProps) {
+  return (
+    <div className="space-y-8">
+      <section className="rounded-3xl border border-white/10 bg-obsidian-900/70 px-6 py-10">
+        <p className="text-xs uppercase tracking-[0.4em] text-white/50">Detalle</p>
+        <h1 className="mt-4 text-3xl font-semibold text-white md:text-4xl">
+          {listing.title}
+        </h1>
+        <p className="mt-3 max-w-2xl text-sm text-white/70">
+          {listing.description || "Sin descripción."}
+        </p>
+      </section>
+
+      <div className="grid gap-8 lg:grid-cols-[minmax(0,420px)_minmax(0,1fr)]">
+        <div className="overflow-hidden rounded-2xl border border-white/10 bg-obsidian-950/70">
+          <div className="relative aspect-square">
+            <Image
+              src={listing.imageUrl || "/placeholders/nft-1.svg"}
+              alt={listing.title}
+              fill
+              className="object-cover"
+              sizes="(max-width: 1024px) 100vw, 420px"
+            />
+          </div>
+        </div>
+
+        <div className="space-y-6 rounded-2xl border border-white/10 bg-obsidian-950/70 p-6 text-sm text-white/70">
+          <div>
+            <p className="text-xs uppercase tracking-[0.3em] text-white/50">
+              Colección
+            </p>
+            <p className="mt-2 text-base text-white/90">
+              {listing.collection || "User Listings"}
+            </p>
+          </div>
+
+          <div>
+            <p className="text-xs uppercase tracking-[0.3em] text-white/50">
+              Offer TXID
+            </p>
+            <p className="mt-2 break-all font-mono text-xs text-white/80">
+              {listing.offerTxId || "No disponible"}
+            </p>
+          </div>
+
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div>
+              <p className="text-xs uppercase tracking-[0.3em] text-white/50">
+                Precio (sats)
+              </p>
+              <p className="mt-2 text-base text-white/90">
+                {listing.priceSats || "—"}
+              </p>
+            </div>
+            <div>
+              <p className="text-xs uppercase tracking-[0.3em] text-white/50">
+                Cantidad
+              </p>
+              <p className="mt-2 text-base text-white/90">
+                {listing.amountAtoms || "—"}
+              </p>
+            </div>
+          </div>
+
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div>
+              <p className="text-xs uppercase tracking-[0.3em] text-white/50">
+                Token ID
+              </p>
+              <p className="mt-2 break-all text-xs text-white/80">
+                {listing.tokenId || "—"}
+              </p>
+            </div>
+            <div>
+              <p className="text-xs uppercase tracking-[0.3em] text-white/50">
+                Verificación
+              </p>
+              <p className="mt-2 text-base text-white/90">
+                {listing.verification || "unknown"}
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/lib/registry.ts
+++ b/src/lib/registry.ts
@@ -31,11 +31,24 @@ export function isRegistryPersistent() {
 export async function loadRegistry(): Promise<RegistryListing[]> {
   try {
     const response = await fetch(API_URL);
-    if (!response.ok) throw new Error("Error en la respuesta del servidor");
+    if (!response.ok) throw new Error("Error en servidor");
     const data = await response.json();
-    return Array.isArray(data) ? data : [];
+
+    if (!Array.isArray(data)) {
+      return [];
+    }
+
+    // Normalizamos los campos para que el frontend siempre lea 'offerTxId'
+    return data.map((item: any) => ({
+      ...item,
+      offerTxId: item.offerTxId || item.offertxid || "",
+      tokenId: item.tokenId || item.tokenid || "",
+      priceSats: item.priceSats || item.pricesats || "",
+      amountAtoms: item.amountAtoms || item.amountatoms || "",
+      verification: item.verification || "unknown"
+    }));
   } catch (error) {
-    console.error("Error cargando el registro global:", error);
+    console.error("Error cargando registro:", error);
     return [];
   }
 }


### PR DESCRIPTION
### Motivation

- Accept registry payloads with either camelCase or lowercase field names so the frontend reliably reads `offerTxId` and related fields.
- Ensure the individual item page waits for the VPS registry response instead of using a local JSON snapshot so live listings are displayed.
- Provide a dedicated details component to render registry listings consistently and avoid duplicating markup.
- Improve error logging and handle unexpected server responses to prevent runtime failures.

### Description

- Update `loadRegistry` in `src/lib/registry.ts` to verify the response is an array and normalize fields (`offerTxId`, `tokenId`, `priceSats`, `amountAtoms`, `verification`) by accepting both camelCase and lowercase variants.
- Replace the static item page at `src/app/item/[id]/page.tsx` with a client component that calls `loadRegistry`, manages a `loading` state, and looks up the listing by `params.id`.
- Add a new `src/components/ListingDetails.tsx` component that renders registry listing details (image, collection, offer TXID, price, amount, token ID, verification) using the `RegistryListing` type.
- Make small message/log tweaks in `src/lib/registry.ts` (e.g. `"Error en servidor"` and `"Error cargando registro:"`).

### Testing

- No automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69667293470083328d881927cb0d86eb)