### PR TITLE
walletconnect: fix metadata url, optionalNamespaces, chainId validation, expiry unix timestamp

### DIFF
--- a/src/components/ConnectRMZModal.tsx
+++ b/src/components/ConnectRMZModal.tsx
@@ -68,6 +68,10 @@ export function ConnectRMZModal({ open, onClose, onConnected }: ConnectRMZModalP
         setLoading(false);
         approveRef.current = approval();
         const session = await approveRef.current;
+        console.log(
+          "[WC][Debug] approved namespaces:",
+          JSON.stringify(session.namespaces, null, 2)
+        );
         if (cancelledRef.current) {
           return;
         }

--- a/src/lib/walletconnect.ts
+++ b/src/lib/walletconnect.ts
@@ -6,8 +6,8 @@ import type { SessionTypes } from "@walletconnect/types";
 const CLIENT_METADATA = {
   name: "XOLOLEGEND",
   description: "XOLOLEGEND RMZ marketplace",
-  url: "https://xololegend.com",
-  icons: ["https://xololegend.com/icon.png"]
+  url: "https://www.xololegend.xyz",
+  icons: ["https://www.xololegend.xyz/icon.png"]
 };
 
 let clientPromise: Promise<SignClient> | null = null;
@@ -18,17 +18,21 @@ export async function initSignClient() {
     if (!projectId) {
       throw new Error("Missing NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID");
     }
-    const metadataUrl =
-      process.env.NODE_ENV === "production"
-        ? CLIENT_METADATA.url
-        : typeof window !== "undefined"
-          ? process.env.NEXT_PUBLIC_SITE_URL?.trim() || window.location.origin
-          : CLIENT_METADATA.url;
+    const isProduction = process.env.NODE_ENV === "production";
+    const dynamicOrigin =
+      typeof window !== "undefined"
+        ? process.env.NEXT_PUBLIC_SITE_URL?.trim() || window.location.origin
+        : CLIENT_METADATA.url;
+    const metadataUrl = isProduction ? CLIENT_METADATA.url : dynamicOrigin;
+    const metadataIcons = isProduction
+      ? CLIENT_METADATA.icons
+      : [`${dynamicOrigin.replace(/\/$/, "")}/icon.png`];
     clientPromise = SignClient.init({
       projectId,
       metadata: {
         ...CLIENT_METADATA,
-        url: metadataUrl
+        url: metadataUrl,
+        icons: metadataIcons
       }
     });
   }
@@ -62,7 +66,7 @@ export async function connectWalletConnect(
     new Set([...(options?.events ?? []), "xolos_offer_published", "xolos_offer_consumed"])
   );
   const { uri, approval } = await client.connect({
-    requiredNamespaces: {
+    optionalNamespaces: {
       ecash: {
         chains: ["ecash:mainnet"],
         methods: [
@@ -81,15 +85,50 @@ export async function connectWalletConnect(
   return { uri, approval };
 }
 
+export function getEcashChainIdOrThrow(session: SessionTypes.Struct): string {
+  const namespaces = session.namespaces;
+  if (!namespaces) {
+    throw new Error("WalletConnect session is missing namespaces.");
+  }
+  const ecashNamespace = namespaces.ecash;
+  if (!ecashNamespace) {
+    throw new Error(
+      `WalletConnect session is missing ecash namespace. namespaces=${JSON.stringify(namespaces)}`
+    );
+  }
+  const chains = ecashNamespace.chains;
+  if (!Array.isArray(chains) || chains.length === 0) {
+    throw new Error(
+      `WalletConnect session ecash namespace is missing approved chains. namespaces=${JSON.stringify(namespaces)}`
+    );
+  }
+  if (!chains.includes("ecash:mainnet")) {
+    throw new Error(
+      `WalletConnect session does not include required chain ecash:mainnet. namespaces=${JSON.stringify(namespaces)}`
+    );
+  }
+  return "ecash:mainnet";
+}
+
+async function getEcashChainIdByTopicOrThrow(topic: string): Promise<string> {
+  const client = await initSignClient();
+  const session = client.session.get(topic);
+  if (!session) {
+    throw new Error(`WalletConnect session not found for topic ${topic}.`);
+  }
+  return getEcashChainIdOrThrow(session);
+}
+
 export async function requestAddresses(topic: string): Promise<string[] | null> {
   if (!topic) {
     return null;
   }
   try {
     const client = await initSignClient();
+    const chainId = await getEcashChainIdByTopicOrThrow(topic);
     const response = await client.request({
       topic,
-      chainId: "ecash:mainnet",
+      chainId,
       request: { method: "ecash_getAddresses", params: [] }
     });
     if (Array.isArray(response)) {
@@ -132,14 +171,17 @@ export async function requestSignAndBroadcast({
         ? Math.ceil(timeoutMs / 1000)
         : 300;
   const clampedTtlSeconds = Math.min(604800, Math.max(300, ttlSecondsRaw));
+  const nowSec = Math.floor(Date.now() / 1000);
+  const expiry = nowSec + clampedTtlSeconds;
+  const chainId = await getEcashChainIdByTopicOrThrow(topic);
   return client.request({
     topic,
-    chainId: "ecash:mainnet",
+    chainId,
     request: {
       method: "ecash_signAndBroadcastTransaction",
       params: { offerId: trimmed }
     },
-    expiry: clampedTtlSeconds
+    expiry
   });
 }
 


### PR DESCRIPTION
### Motivation
- Eliminar warnings de metadata (URL/icons) y la deprecación de `requiredNamespaces`, evitar el error “Unsupported chain” al comprar y hacer los errores de WalletConnect más claros y debugueables.
- Mantener comportamiento dinámico en desarrollo pero forzar el dominio final en producción para evitar mismatches en WalletConnect metadata.

### Description
- Actualiza `CLIENT_METADATA` para producción a `https://www.xololegend.xyz` y `https://www.xololegend.xyz/icon.png`, mientras que en entornos no productivos se conserva el origen dinámico; se ajustan también `icons` en dev. (src/lib/walletconnect.ts)
- Cambia `connectWalletConnect()` de `requiredNamespaces` a `optionalNamespaces` solicitando el namespace `ecash` con `chains: ["ecash:mainnet"]`, los métodos `ecash_getAddresses` y `ecash_signAndBroadcastTransaction`, y los eventos custom del proyecto. (src/lib/walletconnect.ts)
- Añade `getEcashChainIdOrThrow(session)` y `getEcashChainIdByTopicOrThrow(topic)` para validar `session.namespaces` y garantizar que `ecash:mainnet` esté aprobado; estos helpers lanzan errores descriptivos que incluyen `JSON.stringify(session.namespaces)`. (src/lib/walletconnect.ts)
- Evita el `chainId` hardcodeado en requests: `requestAddresses` y `requestSignAndBroadcast` resuelven el `chainId` aprobado usando el helper por `topic` antes de llamar a `client.request`. (src/lib/walletconnect.ts)
- Corrige `expiry` en requests para enviar un timestamp Unix (`now + clampedTtlSeconds`) en lugar de pasar TTL en segundos, manteniendo el clamp `300..604800`. (src/lib/walletconnect.ts)
- Agrega log mínimo de diagnóstico tras `approval()` para imprimir los `session.namespaces` aprobados en consola y facilitar debugging en runtime. (src/components/ConnectRMZModal.tsx)
- Se escaneó el código por patrones (`requiredNamespaces`, `ecash:mainnet`, y llamadas `.request({ topic, chainId`) y se aplicaron los cambios en el módulo central de WalletConnect; quedan ocurrencias informativas de `"ecash:mainnet"` en código UI/logs (por ejemplo `ListingCard`) que no afectan las requests ahora validadas desde la sesión. (repositorio)

### Testing
- `npm install` se ejecutó correctamente.
- `npm run lint` pasó sin advertencias ni errores.
- `npm run build` falló en este entorno por una limitación de red al descargar la fuente Google (`Space Grotesk`), lo cual es un problema externo a los cambios realizados y no indica fallo en las modificaciones de WalletConnect.
- Se ejecutó una búsqueda de patrones (`rg`) para verificar sustituciones relevantes y confirmar que las llamadas a WalletConnect ahora resuelven `chainId` desde la sesión; resultados manuales revisados y cambios aplicados en `src/lib/walletconnect.ts`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a30d054cc883329adb788a305410e6)