### PR TITLE
walletconnect: fix expiry to use TTL seconds instead of unix timestamp

### DIFF
--- a/src/lib/walletconnect.ts
+++ b/src/lib/walletconnect.ts
@@ -171,8 +171,6 @@ export async function requestSignAndBroadcast({
         ? Math.ceil(timeoutMs / 1000)
         : 300;
   const clampedTtlSeconds = Math.min(604800, Math.max(300, ttlSecondsRaw));
-  const nowSec = Math.floor(Date.now() / 1000);
-  const expiry = nowSec + clampedTtlSeconds;
   const chainId = await getEcashChainIdByTopicOrThrow(topic);
   return client.request({
     topic,
@@ -181,7 +179,7 @@ export async function requestSignAndBroadcast({
       method: "ecash_signAndBroadcastTransaction",
       params: { offerId: trimmed }
     },
-    expiry
+    expiry: clampedTtlSeconds
   });
 }
 


### PR DESCRIPTION
### Motivation
- WalletConnect v2 requires `expiry` to be a TTL in seconds (300–604800), but the code was passing a Unix timestamp (`now + ttl`) which caused requests to be rejected.

### Description
- In `requestSignAndBroadcast()` (`src/lib/walletconnect.ts`) removed the `nowSec` timestamp calculation and changed `expiry` to `clampedTtlSeconds`, preserving the TTL clamping to `300..604800` and leaving `chainId`/namespaces logic untouched.

### Testing
- Ran `npm run lint -- --file src/lib/walletconnect.ts`, which completed successfully with no ESLint warnings or errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a335e149788332bfa2da7bcc154c59)