### PR TITLE
walletconnect: prefer ecash:1 chainId to avoid unsupported chain in Tonalli

### DIFF
--- a/src/lib/walletconnect.ts
+++ b/src/lib/walletconnect.ts
@@ -85,38 +85,33 @@ export async function connectWalletConnect(
   return { uri, approval };
 }
 
-export function getEcashChainIdOrThrow(session: SessionTypes.Struct): string {
-  const namespaces = session.namespaces;
-  if (!namespaces) {
-    throw new Error("WalletConnect session is missing namespaces.");
+export function getApprovedEcashChainId(
+  session: SessionTypes.Struct | null | undefined
+): string {
+  const chains = session?.namespaces?.ecash?.chains;
+  if (Array.isArray(chains) && chains.includes("ecash:1")) {
+    return "ecash:1";
   }
-  const ecashNamespace = namespaces.ecash;
-  if (!ecashNamespace) {
-    throw new Error(
-      `WalletConnect session is missing ecash namespace. namespaces=${JSON.stringify(namespaces)}`
-    );
+  if (Array.isArray(chains) && chains.length > 0) {
+    return chains[0];
   }
-  const chains = ecashNamespace.chains;
-  if (!Array.isArray(chains) || chains.length === 0) {
-    throw new Error(
-      `WalletConnect session ecash namespace is missing approved chains. namespaces=${JSON.stringify(namespaces)}`
-    );
-  }
-  if (!chains.includes("ecash:mainnet")) {
-    throw new Error(
-      `WalletConnect session does not include required chain ecash:mainnet. namespaces=${JSON.stringify(namespaces)}`
-    );
-  }
-  return "ecash:mainnet";
+  return "ecash:1";
 }
 
-async function getEcashChainIdByTopicOrThrow(topic: string): Promise<string> {
+async function getApprovedEcashChainIdByTopic(topic: string): Promise<string> {
   const client = await initSignClient();
   const session = client.session.get(topic);
   if (!session) {
     throw new Error(`WalletConnect session not found for topic ${topic}.`);
   }
-  return getEcashChainIdOrThrow(session);
+  const chainId = getApprovedEcashChainId(session);
+  console.log(
+    "[WC] using chainId:",
+    chainId,
+    "approved:",
+    session?.namespaces?.ecash?.chains
+  );
+  return chainId;
 }
 
 export async function requestAddresses(topic: string): Promise<string[] | null> {
@@ -125,7 +120,7 @@ export async function requestAddresses(topic: string): Promise<string[] | null> 
   }
   try {
     const client = await initSignClient();
-    const chainId = await getEcashChainIdByTopicOrThrow(topic);
+    const chainId = await getApprovedEcashChainIdByTopic(topic);
     const response = await client.request({
       topic,
       chainId,
@@ -171,7 +166,7 @@ export async function requestSignAndBroadcast({
         ? Math.ceil(timeoutMs / 1000)
         : 300;
   const clampedTtlSeconds = Math.min(604800, Math.max(300, ttlSecondsRaw));
-  const chainId = await getEcashChainIdByTopicOrThrow(topic);
+  const chainId = await getApprovedEcashChainIdByTopic(topic);
   return client.request({
     topic,
     chainId,


### PR DESCRIPTION
### Motivation

- WalletConnect requests were failing with "Unsupported chain" because some wallets (Tonalli/RMZWallet) only accept the numeric CAIP-2 chain `ecash:1` while sessions sometimes include `ecash:mainnet`; requests must prefer `ecash:1` when available.

### Description

- Add `getApprovedEcashChainId(session)` in `src/lib/walletconnect.ts` to normalize approved eCash chains and prefer `ecash:1`, else return the first approved chain, else fallback to `ecash:1`.
- Replace prior chain selection with `getApprovedEcashChainIdByTopic` (topic-based lookup wrapper) and use it in both `requestAddresses` and `requestSignAndBroadcast` so requests no longer hardcode or require `ecash:mainnet`.
- Add debug logging `console.log("[WC] using chainId:", chainId, "approved:", session?.namespaces?.ecash?.chains)` to surface which chainId is used and which chains were approved.
- Preserve the previous TTL handling for request expiry (expiry passed as clamped seconds between `300` and `604800`).

### Testing

- Ran `npm run lint -- --file src/lib/walletconnect.ts` and it completed with no ESLint warnings or errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a338be42a4833287266c127fc7c168)